### PR TITLE
core: CommonException/BaseError

### DIFF
--- a/module/core/exception/src/main/kotlin/BaseError.kt
+++ b/module/core/exception/src/main/kotlin/BaseError.kt
@@ -1,4 +1,4 @@
-interface CommonError {
+interface BaseError {
     val code: String
     val message: String
 }

--- a/module/core/exception/src/main/kotlin/CommonError.kt
+++ b/module/core/exception/src/main/kotlin/CommonError.kt
@@ -1,0 +1,4 @@
+interface CommonError {
+    val code: String
+    val message: String
+}

--- a/module/core/exception/src/main/kotlin/CommonException.kt
+++ b/module/core/exception/src/main/kotlin/CommonException.kt
@@ -1,0 +1,1 @@
+class CommonException(error: CommonError) : RuntimeException(error.message)

--- a/module/core/exception/src/main/kotlin/CommonException.kt
+++ b/module/core/exception/src/main/kotlin/CommonException.kt
@@ -1,1 +1,15 @@
-class CommonException(error: CommonError) : RuntimeException(error.message)
+class CommonException(
+    val code: String,
+    override val message: String
+) : RuntimeException(message) {
+
+    constructor() : this(
+        code = "500",
+        message = "Unexpected Internal Server Error Occurred"
+    )
+
+    constructor(error: BaseError) : this(error.code, error.message)
+
+    constructor(message: String) : this(code = "UNKNOWN", message = message)
+
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,7 @@ dependencyResolutionManagement {
 include(":main-application").apply { project(":main-application").projectDir = file("module/application") }
 
 // core
+include(":core-exception").apply { project(":core-exception").projectDir = file("module/core/exception") }
 include(":core-security").apply { project(":core-security").projectDir = file("module/core/security") }
 
 // infrastructure


### PR DESCRIPTION
로직 상 예외 처리 시 항상 같은 에러 타입 반환을 위해 생성

직접 에러를 던질 경우 모두 `CommonException` 을 던지기로 함

`ControllerAdvice` 등에서 에러가 핸들링 될 때, `code`가 `HttpStatus`에 존재하는 코드라면 (4xx, 5xx)  
해당 상태코드로 반환해주기로 하자
