### PR TITLE
fix: remove redundant implementations and add new rules in CommonException

### DIFF
--- a/module/core/exception/src/main/kotlin/com/ecommerce/BaseErrorCode.kt
+++ b/module/core/exception/src/main/kotlin/com/ecommerce/BaseErrorCode.kt
@@ -1,0 +1,7 @@
+package com.ecommerce
+
+interface BaseErrorCode {
+    val code: String
+    val status: Int
+    val message: String
+}

--- a/module/core/exception/src/main/kotlin/com/ecommerce/CommonErrorResponse.kt
+++ b/module/core/exception/src/main/kotlin/com/ecommerce/CommonErrorResponse.kt
@@ -1,0 +1,10 @@
+package com.ecommerce
+
+import java.time.ZonedDateTime
+
+data class CommonErrorResponse(
+    val code: String,
+    val status: Int,
+    val message: String,
+    val timestamp: String = ZonedDateTime.now().toString()
+)

--- a/module/core/exception/src/main/kotlin/com/ecommerce/CommonException.kt
+++ b/module/core/exception/src/main/kotlin/com/ecommerce/CommonException.kt
@@ -1,20 +1,31 @@
 package com.ecommerce
 
-open class CommonException(
-    val code: String,
-    override val message: String
-) : RuntimeException(message) {
+open class CommonException : RuntimeException {
+    val code: String
+    val status: Int
 
-    constructor(code: Any, message: String) : this(code.toString(), message)
-    constructor(message: String) : this("UNKNOWN", message)
-    constructor() : this(500, "Unexpected Internal Server Error Occurred")
+    constructor() : this("COMMON_999", 500, "Unexpected Internal Server Error Occurred")
 
-    class InvalidValue(message: String = "Invalid Input Format") : CommonException(400, message)
-    class RequiredValue(message: String = "Required Value is Empty") : CommonException(400, message)
-    class Unauthorized(message: String = "Unauthorized access") : CommonException(401, message)
-    class Forbidden(message: String = "Forbidden Data") : CommonException(401, message)
-    class NotFound(message: String = "Data Not Found") : CommonException(404, message)
-    class AlreadyExists(message: String = "Duplicated Data") : CommonException(409, message)
-    class InvalidState(message: String = "Invalid Data State, Already Done Or Cancelled") : CommonException(409, message)
+    constructor(message: String) : this("UNKNOWN", 500, message)
+
+    constructor(e: BaseErrorCode) : super(e.message) {
+        this.code = e.code
+        this.status = e.status
+    }
+
+    constructor(e: BaseErrorCode, message: String = e.message) : super(message) {
+        this.code = e.code
+        this.status = e.status
+    }
+
+    constructor(status: Int) : super() {
+        this.code = "UNKNOWN"
+        this.status = status
+    }
+
+    constructor(code: String, status: Int = 500, message: String) : super(message) {
+        this.code = code
+        this.status = status
+    }
 
 }


### PR DESCRIPTION
## 서버 전반에서 사용할 수 있는 공통 예외 처리 모듈을 설계 및 구현
> 일관된 구조로 처리할 수 있도록 구성했으며 모든 예상된 처리는 `CommonException` 으로 처리할 수 있도록  
> 다른 Exception이 던져진다면 처리 되지 않은 예외로 간주

### BaseErrorCode
 
- 각 도메인에서 이를 구현해 구체적인 에러 정의 용도
- 에러 코드, HTTP 상태 코드 등과 분리 및 매핑 

### CommonException
> 서버 전반에서 발생 가능한 예외를 포괄할 수 있도록 설계된 공통 예외 클래스.
HTTP 상태 코드, 메시지, 에러 코드 등을 명시적으로 포함.

- 기본 생성자 외에도 다양한 상황을 처리할 수 있도록 생성자 오버로드 구성
  - BaseErrorCode 인터페이스를 통해 사전 정의된 에러 코드로 예외를 명확하게 분류

### CommonErrorResponse (DTO)
> 공통 클라이언트 전달 DTO

- 각 도메인 인터페이스 계층에서 활용 필요
- 에러 코드 분리 관리 및 HTTP 응답 코드와 매핑 용이